### PR TITLE
username and password can read from environment variable 

### DIFF
--- a/config.go
+++ b/config.go
@@ -52,8 +52,8 @@ func loadConfig(r io.Reader) (*config, error) {
 func loadConfigFromEnv() (*config, error) {
 	return &config{
 		Default: &blogConfig{
-			Username: os.Getenv("BLOG_USERNAME"),
-			Password: os.Getenv("BLOG_PASSWORD"),
+			Username: os.Getenv("BLOGSYNC_USERNAME"),
+			Password: os.Getenv("BLOGSYNC_PASSWORD"),
 		},
 	}, nil
 }

--- a/config.go
+++ b/config.go
@@ -3,6 +3,7 @@ package main
 import (
 	"io"
 	"io/ioutil"
+	"os"
 
 	"gopkg.in/yaml.v2"
 )
@@ -46,6 +47,15 @@ func loadConfig(r io.Reader) (*config, error) {
 		b.RemoteRoot = key
 	}
 	return c, nil
+}
+
+func loadConfigFromEnv() (*config, error) {
+	return &config{
+		Default: &blogConfig{
+			Username: os.Getenv("BLOG_USERNAME"),
+			Password: os.Getenv("BLOG_PASSWORD"),
+		},
+	}, nil
 }
 
 func (c *config) Get(remoteRoot string) *blogConfig {

--- a/config_test.go
+++ b/config_test.go
@@ -195,14 +195,14 @@ func TestLoadConfigration(t *testing.T) {
 			t.Fatal(err)
 		}
 		origHome := os.Getenv("HOME")
-		origBlogUsername := os.Getenv("BLOG_USERNAME")
-		origBlogPassword := os.Getenv("BLOG_PASSWORD")
+		origBlogsyncUsername := os.Getenv("BLOGSYNC_USERNAME")
+		origBlogsyncPassword := os.Getenv("BLOGSYNC_PASSWORD")
 		origPwd, _ := os.Getwd()
 		cleanup := func() {
 			os.RemoveAll(tempdir)
 			os.Setenv("HOME", origHome)
-			os.Setenv("BLOG_USERNAME", origBlogUsername)
-			os.Setenv("BLOG_PASSWORD", origBlogPassword)
+			os.Setenv("BLOGSYNC_USERNAME", origBlogsyncUsername)
+			os.Setenv("BLOGSYNC_PASSWORD", origBlogsyncPassword)
 			os.Chdir(origPwd)
 		}
 
@@ -237,13 +237,13 @@ func TestLoadConfigration(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		err = os.Setenv("BLOG_USERNAME", envUsername)
+		err = os.Setenv("BLOGSYNC_USERNAME", envUsername)
 		if err != nil {
 			cleanup()
 			t.Fatal(err)
 		}
 
-		err = os.Setenv("BLOG_PASSWORD", envPassword)
+		err = os.Setenv("BLOGSYNC_PASSWORD", envPassword)
 		if err != nil {
 			cleanup()
 			t.Fatal(err)

--- a/config_test.go
+++ b/config_test.go
@@ -187,3 +187,184 @@ func TestLoadConfigFiles(t *testing.T) {
 		})
 	}
 }
+
+func TestLoadConfigration(t *testing.T) {
+	setup := func(t *testing.T, envUsername string, envPassword string, localConf, globalConf *string) func() {
+		tempdir, err := ioutil.TempDir("", "blogsync-test")
+		if err != nil {
+			t.Fatal(err)
+		}
+		origHome := os.Getenv("HOME")
+		origBlogUsername := os.Getenv("BLOG_USERNAME")
+		origBlogPassword := os.Getenv("BLOG_PASSWORD")
+		origPwd, _ := os.Getwd()
+		cleanup := func() {
+			os.RemoveAll(tempdir)
+			os.Setenv("HOME", origHome)
+			os.Setenv("BLOG_USERNAME", origBlogUsername)
+			os.Setenv("BLOG_PASSWORD", origBlogPassword)
+			os.Chdir(origPwd)
+		}
+
+		os.Chdir(tempdir)
+
+		if localConf != nil {
+			err := ioutil.WriteFile(
+				filepath.Join(tempdir, "blogsync.yaml"), []byte(*localConf), 0755)
+			if err != nil {
+				cleanup()
+				t.Fatal(err)
+			}
+		}
+
+		if globalConf != nil {
+			globalConfFile := filepath.Join(tempdir, ".config", "blogsync", "config.yaml")
+			err := os.MkdirAll(filepath.Dir(globalConfFile), 0755)
+			if err != nil {
+				cleanup()
+				t.Fatal(err)
+			}
+			err = ioutil.WriteFile(globalConfFile, []byte(*globalConf), 0755)
+			if err != nil {
+				cleanup()
+				t.Fatal(err)
+			}
+		}
+
+		err = os.Setenv("HOME", tempdir)
+		if err != nil {
+			cleanup()
+			t.Fatal(err)
+		}
+
+		err = os.Setenv("BLOG_USERNAME", envUsername)
+		if err != nil {
+			cleanup()
+			t.Fatal(err)
+		}
+
+		err = os.Setenv("BLOG_PASSWORD", envPassword)
+		if err != nil {
+			cleanup()
+			t.Fatal(err)
+		}
+
+		return cleanup
+	}
+
+	pstr := func(str string) *string {
+		return &str
+	}
+	pbool := func(b bool) *bool {
+		return &b
+	}
+	testCases := []struct {
+		name       string
+		envUsername string
+		envPassword string
+		localConf  *string
+		globalConf *string
+
+		blogKey string
+		expect  blogConfig
+	}{
+		{
+			name: "use system environment and system environment has priority over global conf",
+			envUsername: "mmm",
+			envPassword: "pww",
+			localConf: pstr(`---
+              default:
+                local_root: ddd
+              blog1.example.com:`),
+			globalConf: pstr(`---
+              default:
+                username: username
+                password: password
+                local_root: ./data`),
+			blogKey: "blog1.example.com",
+			expect: blogConfig{
+				RemoteRoot: "blog1.example.com",
+				LocalRoot:  "ddd",
+				Username:   "mmm",
+				Password:   "pww",
+			},
+		},
+		{
+			name: "use system environment and system environment has priority over local conf",
+			envUsername: "mmm",
+			envPassword: "pww",
+			localConf: pstr(`---
+              default:
+                username: username
+                password: password
+                local_root: ddd
+              blog1.example.com:`),
+			globalConf: pstr(`---
+              default:
+                local_root: ./data`),
+			blogKey: "blog1.example.com",
+			expect: blogConfig{
+				RemoteRoot: "blog1.example.com",
+				LocalRoot:  "ddd",
+				Username:   "mmm",
+				Password:   "pww",
+			},
+		},
+		{
+			name: "localConf only, and no system environment",
+			envUsername: "",
+			envPassword: "",
+			localConf: pstr(`---
+              blog1.example.com:
+                username: blog1
+                local_root: ./data
+              blog2.example.com:
+                local_root: ./blog2`),
+			globalConf: nil,
+			blogKey:    "blog1.example.com",
+			expect: blogConfig{
+				RemoteRoot: "blog1.example.com",
+				LocalRoot:  "./data",
+				Username:   "blog1",
+			},
+		},
+		{
+			name: "inherit default config, and no system environment",
+			envUsername: "",
+			envPassword: "",
+			localConf: nil,
+			globalConf: pstr(`---
+              default:
+                username: hoge
+                password: fuga
+                local_root: ./data
+                omit_domain: false
+              blog2.example.com:
+                local_root: ./blog2`),
+			blogKey: "blog2.example.com",
+			expect: blogConfig{
+				RemoteRoot: "blog2.example.com",
+				LocalRoot:  "./blog2",
+				Username:   "hoge",
+				Password:   "fuga",
+				OmitDomain: pbool(false),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			teardown := setup(t, tc.envUsername, tc.envPassword, tc.localConf, tc.globalConf)
+			defer teardown()
+			conf, err := loadConfiguration()
+			if err != nil {
+				t.Errorf("error should be nil but: %s", err)
+			}
+			out := conf.Get(tc.blogKey)
+
+			if !reflect.DeepEqual(*out, tc.expect) {
+				t.Errorf("something went wrong.\n   out: %+v\nexpect: %+v", *out, tc.expect)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -47,7 +47,26 @@ func loadConfiguration() (*config, error) {
 	if err != nil {
 		return nil, err
 	}
-	return loadConfigFiles(pwd)
+
+	var conf *config
+	conf, err = loadConfigFiles(pwd)
+	if err != nil {
+		return nil, err
+	}
+
+	var confEnv *config
+	confEnv, err = loadConfigFromEnv()
+	if err != nil {
+		return nil, err
+	}
+	if confEnv.Default.Username != "" {
+		conf.Default.Username = confEnv.Default.Username
+	}
+	if confEnv.Default.Password != "" {
+		conf.Default.Password = confEnv.Default.Password
+	}
+
+	return conf, nil
 }
 
 func loadConfigFiles(pwd string) (*config, error) {


### PR DESCRIPTION
when use with CD (Continuous Delivery) Pipeline, i don't want to write a password in the configuration file. so, pass password and username to blogsync using environment variable.

for example, if `blogsync.yaml` is:

```yaml
nabeop.hatenablog.com:
  local_root: .
```

execute `blogsync post` as:

```yaml
jobs:
  publish:
    runs-on: ubuntu-latest
    - name: publish
      env:
        BLOG_PASSWORD: ${{ secrets.blog_password }}
        BLOG_USERNAME: ${{ secrets.blog_username }}      
      run: blogsync post <path/to/new/entry.md>
```