### PR TITLE
AtomPub API のエンドポイントにownerを設定できるように修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,20 @@ default:
 - `<blog>.password`: そのブログに投稿するための API キー。はてなユーザのパスワードではありません。ブログの詳細設定画面 の「APIキー」で確認できます。
 - `<blog>.local_root`: ブログのエントリを格納するパスのルート。
 - `<blog>.omit_domain`: ブログエントリを格納するパスにドメインを含めません。
+- `<blog>.blog_owner`: 編集対象のブログオーナーが自身とは別のユーザーの場合、ブログオーナーを個別に設定できます。
 
 設定ファイルは、 `blogsync.yaml` というファイルがカレントディレクトリにある場合、それも使われます。
+
+#### ブログオーナーが自身とは別の場合の設定
+
+複数人で編集するブログなどで、編集者とブログのオーナーが別ユーザーの場合は下記のように設定できます。
+
+```yaml
+example.hatenablog.com:
+  username: sample
+  password: <API KEY>
+  blog_owner: <BLOG OWNER NAME>
+```
 
 ### エントリをダウンロードする（blogsync pull）
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ default:
 - `<blog>.password`: そのブログに投稿するための API キー。はてなユーザのパスワードではありません。ブログの詳細設定画面 の「APIキー」で確認できます。
 - `<blog>.local_root`: ブログのエントリを格納するパスのルート。
 - `<blog>.omit_domain`: ブログエントリを格納するパスにドメインを含めません。
-- `<blog>.blog_owner`: 編集対象のブログオーナーが自身とは別のユーザーの場合、ブログオーナーを個別に設定できます。
+- `<blog>.owner`: 編集対象のブログオーナーが自身とは別のユーザーの場合、ブログオーナーを個別に設定できます。
 
 設定ファイルは、 `blogsync.yaml` というファイルがカレントディレクトリにある場合、それも使われます。
 
@@ -58,7 +58,7 @@ default:
 example.hatenablog.com:
   username: sample
   password: <API KEY>
-  blog_owner: <BLOG OWNER NAME>
+  owner: <OWNER>
 ```
 
 ### エントリをダウンロードする（blogsync pull）

--- a/broker.go
+++ b/broker.go
@@ -156,9 +156,9 @@ func (b *broker) PostEntry(e *entry) error {
 }
 
 func entryEndPointUrl(bc *blogConfig) string {
-	blogOwner := bc.BlogOwner
-	if blogOwner == "" {
-		blogOwner = bc.Username
+	owner := bc.Owner
+	if owner == "" {
+		owner = bc.Username
 	}
-	return fmt.Sprintf("https://blog.hatena.ne.jp/%s/%s/atom/entry", blogOwner, bc.RemoteRoot)
+	return fmt.Sprintf("https://blog.hatena.ne.jp/%s/%s/atom/entry", owner, bc.RemoteRoot)
 }

--- a/broker.go
+++ b/broker.go
@@ -32,7 +32,7 @@ func newBroker(bc *blogConfig) *broker {
 
 func (b *broker) FetchRemoteEntries() ([]*entry, error) {
 	entries := []*entry{}
-	url := fmt.Sprintf("https://blog.hatena.ne.jp/%s/%s/atom/entry", b.Username, b.RemoteRoot)
+	url := entryEndPointUrl(b.blogConfig)
 
 	for {
 		feed, err := b.Client.GetFeed(url)
@@ -142,8 +142,8 @@ func (b *broker) PutEntry(e *entry) error {
 }
 
 func (b *broker) PostEntry(e *entry) error {
-	postURL := fmt.Sprintf("https://blog.hatena.ne.jp/%s/%s/atom/entry", b.Username, b.RemoteRoot)
-	newEntry, err := asEntry(b.Client.PostEntry(postURL, e.atom()))
+	endPoint := entryEndPointUrl(b.blogConfig)
+	newEntry, err := asEntry(b.Client.PostEntry(endPoint, e.atom()))
 	if err != nil {
 		return err
 	}
@@ -153,4 +153,12 @@ func (b *broker) PostEntry(e *entry) error {
 
 	path := b.LocalPath(newEntry)
 	return b.Store(newEntry, path)
+}
+
+func entryEndPointUrl(bc *blogConfig) string {
+	blogOwner := bc.BlogOwner
+	if blogOwner == "" {
+		blogOwner = bc.Username
+	}
+	return fmt.Sprintf("https://blog.hatena.ne.jp/%s/%s/atom/entry", blogOwner, bc.RemoteRoot)
 }

--- a/broker_test.go
+++ b/broker_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestEntryEndPointUrl(t *testing.T) {
+	testCases := []struct {
+		name string
+		config blogConfig
+		expect string
+	}{
+		{
+			name: "username",
+			config: blogConfig{
+				RemoteRoot: "example1.hatenablog.com",
+				Username:   "sample1",
+			},
+			expect: "https://blog.hatena.ne.jp/sample1/example1.hatenablog.com/atom/entry",
+		},
+		{
+			name: "blogowner",
+			config: blogConfig{
+				RemoteRoot: "example1.hatenablog.com",
+				Username:   "sample1",
+				BlogOwner:  "sample2",
+			},
+			expect: "https://blog.hatena.ne.jp/sample2/example1.hatenablog.com/atom/entry",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := entryEndPointUrl(&tc.config)
+			assert.Equal(t, tc.expect, got)
+		})
+	}
+}

--- a/broker_test.go
+++ b/broker_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestEntryEndPointUrl(t *testing.T) {
 	testCases := []struct {
-		name string
+		name   string
 		config blogConfig
 		expect string
 	}{
@@ -20,11 +20,11 @@ func TestEntryEndPointUrl(t *testing.T) {
 			expect: "https://blog.hatena.ne.jp/sample1/example1.hatenablog.com/atom/entry",
 		},
 		{
-			name: "blogowner",
+			name: "owner",
 			config: blogConfig{
 				RemoteRoot: "example1.hatenablog.com",
 				Username:   "sample1",
-				BlogOwner:  "sample2",
+				Owner:      "sample2",
 			},
 			expect: "https://blog.hatena.ne.jp/sample2/example1.hatenablog.com/atom/entry",
 		},

--- a/config.go
+++ b/config.go
@@ -18,8 +18,8 @@ type blogConfig struct {
 	LocalRoot  string `yaml:"local_root"`
 	Username   string
 	Password   string
-	OmitDomain *bool `yaml:"omit_domain"`
-	BlogOwner  string `yaml:"blog_owner"`
+	OmitDomain *bool  `yaml:"omit_domain"`
+	Owner      string `yaml:"owner"`
 }
 
 func loadConfig(r io.Reader) (*config, error) {

--- a/config.go
+++ b/config.go
@@ -19,6 +19,7 @@ type blogConfig struct {
 	Username   string
 	Password   string
 	OmitDomain *bool `yaml:"omit_domain"`
+	BlogOwner  string `yaml:"blog_owner"`
 }
 
 func loadConfig(r io.Reader) (*config, error) {

--- a/config_test.go
+++ b/config_test.go
@@ -169,6 +169,25 @@ func TestLoadConfigFiles(t *testing.T) {
 				Password:   "pww",
 			},
 		},
+		{
+			name:      "BlogOwner",
+			localConf: nil,
+			globalConf: pstr(`---
+              blog1.example.com:
+                username: blog1
+                local_root: ./data
+                blog_owner: sample1
+              blog2.example.com:
+                local_root: ./blog2
+                blog_owner: sample2`),
+			blogKey: "blog1.example.com",
+			expect: blogConfig{
+				RemoteRoot: "blog1.example.com",
+				LocalRoot:  "./data",
+				Username:   "blog1",
+				BlogOwner:  "sample1",
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/config_test.go
+++ b/config_test.go
@@ -170,22 +170,22 @@ func TestLoadConfigFiles(t *testing.T) {
 			},
 		},
 		{
-			name:      "BlogOwner",
+			name:      "Owner",
 			localConf: nil,
 			globalConf: pstr(`---
               blog1.example.com:
                 username: blog1
                 local_root: ./data
-                blog_owner: sample1
+                owner: sample1
               blog2.example.com:
                 local_root: ./blog2
-                blog_owner: sample2`),
+                owner: sample2`),
 			blogKey: "blog1.example.com",
 			expect: blogConfig{
 				RemoteRoot: "blog1.example.com",
 				LocalRoot:  "./data",
 				Username:   "blog1",
-				BlogOwner:  "sample1",
+				Owner:      "sample1",
 			},
 		},
 	}
@@ -355,7 +355,7 @@ func TestLoadConfigration(t *testing.T) {
               blog1.example.com:
                 local_root: ./data`),
 			globalConf: nil,
-			blogKey: "blog1.example.com",
+			blogKey:    "blog1.example.com",
 			expect: blogConfig{
 				RemoteRoot: "blog1.example.com",
 				LocalRoot:  "./data",


### PR DESCRIPTION
## 背景

- 2022年6月16日の[はてなブログAtomPub](https://developer.hatena.ne.jp/ja/documents/blog/apis/atom/#%E5%A4%89%E6%9B%B4%E5%B1%A5%E6%AD%B4)にの変更によりAtomPub APIがブログメンバーにも対応した
  - AtomPub API のエンドポイントは `https://blog.hatena.ne.jp/<ブログオーナーのはてな ID>/<ブログ ID>/atom/entry/<entry_id>` が期待されている
  - blogsync は `https://blog.hatena.ne.jp/<blogsync_username>/<ブログ ID>/atom/entry/<entry_id>` というフォーマットでエンドポイントを扱っている
  - そのため複数人で編集する場合、`<blogsync_username> != <ブログオーナーのはてな ID>` となるので、ブログオーナー以外は編集できない状態となっている

## 解決策

- configでblog_ownerを設定できるように変更し、blog_ownerが設定されている場合はAtomPub API のエンドポイントにblog_ownerが設定されるように修正しました

