### PR TITLE
Enable stdin on windows

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"runtime"
 	"strings"
 	"time"
 
@@ -188,12 +189,17 @@ func entryFromReader(source io.Reader) (*entry, error) {
 	}
 
 	if f, ok := source.(*os.File); ok {
-		fi, err := os.Stat(f.Name())
-		if err != nil {
-			return nil, err
+		if runtime.GOOS == "windows" && f.Name() == os.Stdin.Name() {
+			t := time.Now()
+			entry.LastModified = &t	
+		} else {
+			fi, err := os.Stat(f.Name())
+			if err != nil {
+				return nil, err
+			}
+			t := fi.ModTime()
+			entry.LastModified = &t
 		}
-		t := fi.ModTime()
-		entry.LastModified = &t
 	}
 
 	return entry, nil


### PR DESCRIPTION
An error occurred in the entryFromReader() function where the entry time was being obtained.

On Windows, it is not possible to os.Stat() for "/dev/stdin".

On Windows with standard input, the entry is set to the current time.