### PR TITLE
support fixed pages

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -32,9 +32,18 @@ func newBroker(bc *blogConfig) *broker {
 
 func (b *broker) FetchRemoteEntries() ([]*entry, error) {
 	entries := []*entry{}
-	url := entryEndPointUrl(b.blogConfig)
+	urls := []string{
+		entryEndPointUrl(b.blogConfig),
+		fixedPageEndpointURL(b.blogConfig),
+	}
+	for url := ""; true; {
+		if url == "" {
+			if len(urls) == 0 {
+				break
+			}
+			url, urls = urls[0], urls[1:]
+		}
 
-	for {
 		feed, err := b.Client.GetFeed(url)
 		if err != nil {
 			return nil, err
@@ -45,16 +54,15 @@ func (b *broker) FetchRemoteEntries() ([]*entry, error) {
 			if err != nil {
 				return nil, err
 			}
-
 			entries = append(entries, e)
 		}
 
 		nextLink := feed.Links.Find("next")
-		if nextLink == nil {
-			break
+		if nextLink != nil {
+			url = nextLink.Href
+		} else {
+			url = ""
 		}
-
-		url = nextLink.Href
 	}
 
 	return entries, nil
@@ -66,6 +74,13 @@ func (b *broker) LocalPath(e *entry) string {
 	if b.OmitDomain == nil || !*b.OmitDomain {
 		paths = append(paths, b.BlogID)
 	}
+	// If possible, for fixed pages, we would like to dig a directory such as page/ to place md files,
+	// but it is difficult to solve by a simple method such as prepending a "page/" string
+	// if the path does not begin with an entry string. That is because if you are operating
+	// a subdirectory in Hatena Blog Media, you do not know where the root of the blog is.
+	// e.g.
+	// - https://example.com/subblog/entry/blog-entry
+	// - https://example.com/subblog/fixed-page
 	paths = append(paths, e.URL.Path+extension)
 	return filepath.Join(paths...)
 }
@@ -161,4 +176,12 @@ func entryEndPointUrl(bc *blogConfig) string {
 		owner = bc.Username
 	}
 	return fmt.Sprintf("https://blog.hatena.ne.jp/%s/%s/atom/entry", owner, bc.BlogID)
+}
+
+func fixedPageEndpointURL(bc *blogConfig) string {
+	owner := bc.Owner
+	if owner == "" {
+		owner = bc.Username
+	}
+	return fmt.Sprintf("https://blog.hatena.ne.jp/%s/%s/atom/page", owner, bc.BlogID)
 }

--- a/broker.go
+++ b/broker.go
@@ -156,8 +156,13 @@ func (b *broker) PutEntry(e *entry) error {
 	return b.Store(newEntry, path)
 }
 
-func (b *broker) PostEntry(e *entry) error {
-	endPoint := entryEndPointUrl(b.blogConfig)
+func (b *broker) PostEntry(e *entry, isPage bool) error {
+	var endPoint string
+	if !isPage {
+		endPoint = entryEndPointUrl(b.blogConfig)
+	} else {
+		endPoint = fixedPageEndpointURL(b.blogConfig)
+	}
 	newEntry, err := asEntry(b.Client.PostEntry(endPoint, e.atom()))
 	if err != nil {
 		return err

--- a/main.go
+++ b/main.go
@@ -184,6 +184,7 @@ var commandPost = &cli.Command{
 		&cli.BoolFlag{Name: "draft"},
 		&cli.StringFlag{Name: "title"},
 		&cli.StringFlag{Name: "custom-path"},
+		&cli.BoolFlag{Name: "page"},
 	},
 	Action: func(c *cli.Context) error {
 		blog := c.Args().First()
@@ -219,7 +220,7 @@ var commandPost = &cli.Command{
 		}
 
 		b := newBroker(blogConfig)
-		err = b.PostEntry(entry)
+		err = b.PostEntry(entry, c.Bool("page"))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
resolve #60

元々の挙動としてブログ記事は `entry/` 配下に配置される。そして、このpull requestでは固定ページは、`localRoot` 直下に配置されるようになった。つまり `page/` などのディレクトリを掘ってそこに配置するようにはしなかったということ。具体的には以下のような感じ

```
.
├── entry
│   ├── entry1.md
│   └── entry2.md
├── page1.md
└── page2.md
```

`page/` を掘らなかった理由としては

- 公開URLと階層構造が同じになるので分かりやすい
- ブログメディアでサブディレクトリ運用にしている場合に page をどう掘るかが難しい
    - 例えば、 example.com/subdirblog/ とかの場合、現状 `./subdirblog/entry/entry1.md` とかにpullされる

というのがある



