### PR TITLE
[breaking change] normalize localRoot to absolute path

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -79,13 +79,13 @@ func TestLoadConfigFiles(t *testing.T) {
 			globalConf: pstr(`---
               blog1.example.com:
                 username: blog1
-                local_root: ./data
+                local_root: /data
               blog2.example.com:
-                local_root: ./blog2`),
+                local_root: /blog2`),
 			blogKey: "blog1.example.com",
 			expect: blogConfig{
 				BlogID:    "blog1.example.com",
-				LocalRoot: "./data",
+				LocalRoot: "/data",
 				Username:  "blog1",
 			},
 		},
@@ -94,13 +94,13 @@ func TestLoadConfigFiles(t *testing.T) {
 			localConf: nil,
 			globalConf: pstr(`---
               default:
-                local_root: ./data
+                local_root: /data
               blog1.example.com:
                 username: blog1`),
 			blogKey: "blog1.example.com",
 			expect: blogConfig{
 				BlogID:    "blog1.example.com",
-				LocalRoot: "./data",
+				LocalRoot: "/data",
 				Username:  "blog1",
 			},
 		},
@@ -111,14 +111,14 @@ func TestLoadConfigFiles(t *testing.T) {
               default:
                 username: hoge
                 password: fuga
-                local_root: ./data
+                local_root: /data
                 omit_domain: false
               blog2.example.com:
-                local_root: ./blog2`),
+                local_root: /blog2`),
 			blogKey: "blog2.example.com",
 			expect: blogConfig{
 				BlogID:     "blog2.example.com",
-				LocalRoot:  "./blog2",
+				LocalRoot:  "/blog2",
 				Username:   "hoge",
 				Password:   "fuga",
 				OmitDomain: pbool(false),
@@ -129,14 +129,14 @@ func TestLoadConfigFiles(t *testing.T) {
 			localConf: pstr(`---
               blog1.example.com:
                 username: blog1
-                local_root: ./data
+                local_root: /data
               blog2.example.com:
-                local_root: ./blog2`),
+                local_root: /blog2`),
 			globalConf: nil,
 			blogKey:    "blog1.example.com",
 			expect: blogConfig{
 				BlogID:    "blog1.example.com",
-				LocalRoot: "./data",
+				LocalRoot: "/data",
 				Username:  "blog1",
 			},
 		},
@@ -145,7 +145,7 @@ func TestLoadConfigFiles(t *testing.T) {
 			localConf: pstr(`---
               blog1.example.com:
                 username: blog1
-                local_root: .`),
+                local_root: /`),
 			globalConf: pstr(`---
               blog1.example.com:
                 password: pww
@@ -153,7 +153,7 @@ func TestLoadConfigFiles(t *testing.T) {
 			blogKey: "blog1.example.com",
 			expect: blogConfig{
 				BlogID:    "blog1.example.com",
-				LocalRoot: ".",
+				LocalRoot: "/",
 				Username:  "blog1",
 				Password:  "pww",
 			},
@@ -162,17 +162,17 @@ func TestLoadConfigFiles(t *testing.T) {
 			name: "empty configuration",
 			localConf: pstr(`---
               default:
-                local_root: ddd
+                local_root: /ddd
               blog1.example.com:`),
 			globalConf: pstr(`---
               default:
                 username: mmm
                 password: pww
-                local_root: ./data`),
+                local_root: /data`),
 			blogKey: "blog1.example.com",
 			expect: blogConfig{
 				BlogID:    "blog1.example.com",
-				LocalRoot: "ddd",
+				LocalRoot: "/ddd",
 				Username:  "mmm",
 				Password:  "pww",
 			},
@@ -183,15 +183,15 @@ func TestLoadConfigFiles(t *testing.T) {
 			globalConf: pstr(`---
               blog1.example.com:
                 username: blog1
-                local_root: ./data
+                local_root: /data
                 owner: sample1
               blog2.example.com:
-                local_root: ./blog2
+                local_root: /blog2
                 owner: sample2`),
 			blogKey: "blog1.example.com",
 			expect: blogConfig{
 				BlogID:    "blog1.example.com",
-				LocalRoot: "./data",
+				LocalRoot: "/data",
 				Username:  "blog1",
 				Owner:     "sample1",
 			},
@@ -301,17 +301,17 @@ func TestLoadConfigration(t *testing.T) {
 			envPassword: "pww",
 			localConf: pstr(`---
               default:
-                local_root: ddd
+                local_root: /ddd
               blog1.example.com:`),
 			globalConf: pstr(`---
               default:
                 username: username
                 password: password
-                local_root: ./data`),
+                local_root: /data`),
 			blogKey: "blog1.example.com",
 			expect: blogConfig{
 				BlogID:    "blog1.example.com",
-				LocalRoot: "ddd",
+				LocalRoot: "/ddd",
 				Username:  "mmm",
 				Password:  "pww",
 			},
@@ -324,15 +324,15 @@ func TestLoadConfigration(t *testing.T) {
               default:
                 username: username
                 password: password
-                local_root: ddd
+                local_root: /ddd
               blog1.example.com:`),
 			globalConf: pstr(`---
               default:
-                local_root: ./data`),
+                local_root: /data`),
 			blogKey: "blog1.example.com",
 			expect: blogConfig{
 				BlogID:    "blog1.example.com",
-				LocalRoot: "ddd",
+				LocalRoot: "/ddd",
 				Username:  "mmm",
 				Password:  "pww",
 			},
@@ -344,14 +344,14 @@ func TestLoadConfigration(t *testing.T) {
 			localConf: pstr(`---
               blog1.example.com:
                 username: blog1
-                local_root: ./data
+                local_root: /data
               blog2.example.com:
-                local_root: ./blog2`),
+                local_root: /blog2`),
 			globalConf: nil,
 			blogKey:    "blog1.example.com",
 			expect: blogConfig{
 				BlogID:    "blog1.example.com",
-				LocalRoot: "./data",
+				LocalRoot: "/data",
 				Username:  "blog1",
 			},
 		},
@@ -361,12 +361,12 @@ func TestLoadConfigration(t *testing.T) {
 			envPassword: "pww",
 			localConf: pstr(`---
               blog1.example.com:
-                local_root: ./data`),
+                local_root: /data`),
 			globalConf: nil,
 			blogKey:    "blog1.example.com",
 			expect: blogConfig{
 				BlogID:    "blog1.example.com",
-				LocalRoot: "./data",
+				LocalRoot: "/data",
 				Username:  "mmm",
 				Password:  "pww",
 			},
@@ -380,14 +380,14 @@ func TestLoadConfigration(t *testing.T) {
               default:
                 username: hoge
                 password: fuga
-                local_root: ./data
+                local_root: /data
                 omit_domain: false
               blog2.example.com:
-                local_root: ./blog2`),
+                local_root: /blog2`),
 			blogKey: "blog2.example.com",
 			expect: blogConfig{
 				BlogID:     "blog2.example.com",
-				LocalRoot:  "./blog2",
+				LocalRoot:  "/blog2",
 				Username:   "hoge",
 				Password:   "fuga",
 				OmitDomain: pbool(false),

--- a/config_test.go
+++ b/config_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -29,6 +30,10 @@ func TestLoadConfigFiles(t *testing.T) {
 		}
 
 		if localConf != nil {
+			if runtime.GOOS == "windows" {
+				*localConf = strings.ReplaceAll(*localConf, "local_root: /", "local_root: D:/")
+			}
+
 			err := ioutil.WriteFile(
 				filepath.Join(tempdir, "blogsync.yaml"), []byte(*localConf), 0755)
 			if err != nil {
@@ -38,6 +43,9 @@ func TestLoadConfigFiles(t *testing.T) {
 		}
 
 		if globalConf != nil {
+			if runtime.GOOS == "windows" {
+				*globalConf = strings.ReplaceAll(*globalConf, "local_root: /", "local_root: D:/")
+			}
 			globalConfFile := filepath.Join(tempdir, ".config", "blogsync", "config.yaml")
 			err := os.MkdirAll(filepath.Dir(globalConfFile), 0755)
 			if err != nil {
@@ -208,6 +216,10 @@ func TestLoadConfigFiles(t *testing.T) {
 			}
 			out := conf.Get(tc.blogKey)
 
+			if runtime.GOOS == "windows" {
+				out.LocalRoot = filepath.Clean(out.LocalRoot)
+				tc.expect.LocalRoot = filepath.Clean("D:" + tc.expect.LocalRoot)
+			}
 			if !reflect.DeepEqual(*out, tc.expect) {
 				t.Errorf("something went wrong.\n   out: %+v\nexpect: %+v", *out, tc.expect)
 			}
@@ -236,6 +248,9 @@ func TestLoadConfigration(t *testing.T) {
 		os.Chdir(tempdir)
 
 		if localConf != nil {
+			if runtime.GOOS == "windows" {
+				*localConf = strings.ReplaceAll(*localConf, "local_root: /", "local_root: D:/")
+			}
 			err := ioutil.WriteFile(
 				filepath.Join(tempdir, "blogsync.yaml"), []byte(*localConf), 0755)
 			if err != nil {
@@ -245,6 +260,9 @@ func TestLoadConfigration(t *testing.T) {
 		}
 
 		if globalConf != nil {
+			if runtime.GOOS == "windows" {
+				*globalConf = strings.ReplaceAll(*globalConf, "local_root: /", "local_root: D:/")
+			}
 			globalConfFile := filepath.Join(tempdir, ".config", "blogsync", "config.yaml")
 			err := os.MkdirAll(filepath.Dir(globalConfFile), 0755)
 			if err != nil {
@@ -405,6 +423,10 @@ func TestLoadConfigration(t *testing.T) {
 			}
 			out := conf.Get(tc.blogKey)
 
+			if runtime.GOOS == "windows" {
+				out.LocalRoot = filepath.Clean(out.LocalRoot)
+				tc.expect.LocalRoot = filepath.Clean("D:" + tc.expect.LocalRoot)
+			}
 			if !reflect.DeepEqual(*out, tc.expect) {
 				t.Errorf("something went wrong.\n   out: %+v\nexpect: %+v", *out, tc.expect)
 			}

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ func loadSingleConfigFile(fname string) (*config, error) {
 		return nil, err
 	}
 	defer f.Close()
-	return loadConfig(f)
+	return loadConfig(f, fname)
 }
 
 func loadConfiguration() (*config, error) {


### PR DESCRIPTION
blogConfig.LocalPathを設定読み込み時に絶対パスに正規化して統一するようにしたい。また、設定ファイルに相対パスが指定されていた場合に、設定ファイルからの相対位置に解決することとしたい。これは統一感や将来の機能拡張のため。具体的には例えば `blogsync push` でファイルの配置位置がどのブログのエントリーか判別するためなどにそのようにしたい。

設定ファイルの位置からの相対位置で絶対パスを解決するようにすると、グローバル設定 (.config/blogsync/config.yaml) に相対パスが設定されていた場合に非互換変更になる。現状はblogsync実行位置からの相対位置でLocalRootが解決されるため。ローカル設定 (blogsync.yaml) の場合は、blogsync実行ディレクトリとファイル配置ディレクトリが同一なので非互換変更にはならない。

ただ、一般的には設定ファイルからの相対位置で相対パスが解決されることが期待されると思うし、実際blogsyncの実行パスによって、エントリーがpullされてくる位置がコロコロ変わるのもおかしな話だと思う。なので、できれば挙動を変えたい。

以下の選択肢がある。

1. 現状の挙動(blogsync実行位置からの相対位置)を維持する
2. globalConfigの場合のみ実行位置からの相対位置とする
    - これは実は1と挙動は同じ。将来的に設定ファイルをコマンドラインオプションで指定できるようにした場合などに変わりうる
    - これは挙動として複雑で紛らわしいので筋が悪い
3. localConfigの場合のみ相対パス設定を許容する
    - globalConfigに相対パスが設定されていたらエラーとする
    - `.config/blogsync/config.yaml` からの相対パスにファイルが書き込まれるの嫌な感じがするのでこれはfool proof的にはやったほうが良いかも
        - 現在グローバル設定に相対パスを指定しているユーザーの挙動が変わることになるので、それまでと違う想定外の位置にpullされるよりかはエラーメッセージを出して知らせたほうが親切という話もある
4. 何も考えず、相対パスを設定ファイルからの相対位置に解決する

今の実装は4。3にはしても良いかも知れない。

→ 3にするのそこをケアするためにコードを複雑にしても仕方ないので一旦実装なくていいかと思った。