### PR TITLE
set the updated to nil when the entry is still draft

### DIFF
--- a/entry_test.go
+++ b/entry_test.go
@@ -100,13 +100,13 @@ func TestDraftFullContent(t *testing.T) {
 }
 
 func TestFrontmatterDraftEntryFromReader(t *testing.T) {
-	jst, _ := time.LoadLocation("Asia/Tokyo")
+	var ti *time.Time
 
 	e, err := entryFromReader(strings.NewReader(draftContent))
 	assert.NoError(t, err)
 
 	assert.Equal(t, "所内#4", e.Title)
-	assert.True(t, e.Date.Equal(time.Date(2012, 12, 20, 0, 0, 0, 0, jst)))
+	assert.Equal(t, e.Date, ti)
 	assert.Equal(t, "http://hatenablog.example.com/2", e.URL.String())
 	assert.Equal(t, "http://hatenablog.example.com/2/edit", e.EditURL)
 	assert.True(t, e.IsDraft)


### PR DESCRIPTION
下書き時にはupdatedは明示的に指定しない限り、はてなブログ内部的には値は代入されていない。

参考: https://github.com/x-motemen/blogsync/blob/master/doc/date.md

今、blogysyncの下書き更新時に、明示的にMarkdown内のDateをupdatedに指定して更新しているが、そうするとupdatedが固定されて実際の日時に追随されなくなり、実際の公開時に過去の日時が公開日時にされてしまうので嬉しくない。

なので、下書き時にはDateは使わないようにする。
(公開したエントリーを下書きに戻した時にもしかしたらちょっと困るかも知れないが、エッジケースなので一旦OKとする)

