### PR TITLE
[incompatible] change log output dest to stderr

### DIFF
--- a/log.go
+++ b/log.go
@@ -2,17 +2,22 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/motemen/go-colorine"
 )
 
-var logger = &colorine.Logger{
-	Prefixes: colorine.Prefixes{
-		"http":  colorine.Verbose,
-		"store": colorine.Info,
-		"error": colorine.Error,
-		"":      colorine.Verbose,
-	},
+var logger *colorine.Logger
+
+func init() {
+	logger = &colorine.Logger{
+		Prefixes: colorine.Prefixes{
+			"http":  colorine.Verbose,
+			"store": colorine.Info,
+			"error": colorine.Error,
+			"":      colorine.Verbose,
+		}}
+	logger.SetOutput(os.Stderr)
 }
 
 func logf(prefix, pattern string, args ...interface{}) {


### PR DESCRIPTION
Logs should generally be sent to stderr, and stdout should be used for pipeline processing.
Specifically, we make this incompatibility change first because we want to output updated files to stdout to coordinate with other processes.