### PR TITLE
Mitigate time skew in time comparisons

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -169,7 +169,7 @@ func (b *broker) UploadFresh(e *entry) (bool, error) {
 		return false, err
 	}
 
-	if e.LastModified.After(*re.LastModified) == false {
+	if !newerWithAllowance(*e.LastModified, *re.LastModified) {
 		return false, nil
 	}
 

--- a/entry.go
+++ b/entry.go
@@ -179,7 +179,7 @@ func entryFromAtom(e *atom.Entry) (*entry, error) {
 	// But if the date is in the future, don't set to nil because it may be a reserved post.
 	// Also preserve the date if it's a scheduled post.
 	updated := e.Updated
-	if updated != nil && isDraft && !isScheduled && !time.Now().Before(*updated) {
+	if updated != nil && isDraft && !isScheduled && nowAfterWithAllowance(*updated) {
 		updated = nil
 	}
 
@@ -223,7 +223,7 @@ func entryFromReader(source io.Reader) (*entry, error) {
 		// Set the updated to nil when the entry is still draft.
 		// But if the date is in the future, don't set to nil because it may be a reserved post.
 		// Also preserve the date if it's a scheduled post.
-		if eh.IsDraft && !eh.IsScheduled && eh.Date != nil && !time.Now().Before(*eh.Date) {
+		if eh.IsDraft && !eh.IsScheduled && eh.Date != nil && nowAfterWithAllowance(*eh.Date) {
 			eh.Date = nil
 		}
 		content = c[2]

--- a/timecmp.go
+++ b/timecmp.go
@@ -1,0 +1,13 @@
+package main
+
+import "time"
+
+const clockSkewAllowance = 3 * time.Second
+
+func newerWithAllowance(local, remote time.Time) bool {
+	return !local.Add(clockSkewAllowance).Before(remote)
+}
+
+func nowAfterWithAllowance(t time.Time) bool {
+	return !time.Now().Add(clockSkewAllowance).Before(t)
+}


### PR DESCRIPTION
## Summary
- add a small clock-skew allowance helper for timestamp comparisons
- use tolerant comparison in UploadFresh to avoid missing updates when remote clock is slightly ahead
- use tolerant now-vs-date checks when clearing draft dates

## Why
TestBlogsync/post_draft_and was failing intermittently because strict time comparison was sensitive to slight server/client clock differences.