### PR TITLE
Treat drafts outside _draft/ as having custom paths

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -132,17 +132,11 @@ func (b *broker) StoreFresh(e *entry, path string) (bool, error) {
 func (b *broker) Store(e *entry, path, origPath string) error {
 	logf("store", "%s", path)
 
-	if e.IsDraft && e.isBlogEntry() {
-		_, entryPath := b.blogConfig.extractEntryPath(e.URL.Path)
-		if entryPath == "" {
-			return fmt.Errorf("invalid path: %s", e.URL.Path)
-		}
-		// Only clear temporary URL for entries stored in _draft/
-		if isLikelyGivenPath(entryPath) {
-			_, destEntryPath := b.blogConfig.extractEntryPath(path)
-			if strings.HasPrefix(destEntryPath, draftDir) {
-				e.URL = nil
-			}
+	if e.IsDraft && e.isBlogEntry() && e.URL != nil {
+		// Clear temporary URL for entries stored in _draft/
+		_, destEntryPath := b.blogConfig.extractEntryPath(path)
+		if strings.HasPrefix(destEntryPath, draftDir) {
+			e.URL = nil
 		}
 	}
 

--- a/broker.go
+++ b/broker.go
@@ -137,8 +137,12 @@ func (b *broker) Store(e *entry, path, origPath string) error {
 		if entryPath == "" {
 			return fmt.Errorf("invalid path: %s", e.URL.Path)
 		}
+		// Only clear temporary URL for entries stored in _draft/
 		if isLikelyGivenPath(entryPath) {
-			e.URL = nil
+			_, destEntryPath := b.blogConfig.extractEntryPath(path)
+			if strings.HasPrefix(destEntryPath, draftDir) {
+				e.URL = nil
+			}
 		}
 	}
 
@@ -181,6 +185,13 @@ func (b *broker) PutEntry(e *entry) error {
 	if err != nil {
 		return err
 	}
+	// Preserve local path for drafts stored outside _draft/
+	if e.localPath != "" && newEntry.IsDraft && newEntry.isBlogEntry() {
+		_, entryPath := b.blogConfig.extractEntryPath(e.localPath)
+		if entryPath != "" && !strings.HasPrefix(entryPath, draftDir) {
+			newEntry.localPath = e.localPath
+		}
+	}
 	return b.Store(newEntry, b.LocalPath(newEntry), b.LocalPath(e))
 }
 
@@ -194,6 +205,13 @@ func (b *broker) PostEntry(e *entry, isPage bool) error {
 	newEntry, err := asEntry(b.Client.PostEntry(endPoint, e.atom()))
 	if err != nil {
 		return err
+	}
+	// Preserve local path for drafts stored outside _draft/
+	if e.localPath != "" && newEntry.IsDraft && newEntry.isBlogEntry() {
+		_, entryPath := b.blogConfig.extractEntryPath(e.localPath)
+		if entryPath != "" && !strings.HasPrefix(entryPath, draftDir) {
+			newEntry.localPath = e.localPath
+		}
 	}
 	return b.Store(newEntry, b.LocalPath(newEntry), "")
 }

--- a/entry.go
+++ b/entry.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
@@ -318,6 +319,7 @@ func modTime(fpath string) (time.Time, error) {
 }
 
 func (bc *blogConfig) extractEntryPath(p string) (subdir string, entryPath string) {
+	p = filepath.ToSlash(p)
 	entryDir := bc.entryDirectory()
 	if entryDir == "" {
 		entryPath = strings.TrimSuffix(p, entryExt)

--- a/main.go
+++ b/main.go
@@ -227,8 +227,10 @@ var commandPush = &cli.Command{
 			blogPath = "/" + filepath.ToSlash(blogPath)
 
 			if _, entryPath := bc.extractEntryPath(path); entryPath != "" {
-				if !isLikelyGivenPath(entryPath) && !strings.HasPrefix(entryPath, draftDir) {
-					entry.CustomPath = entryPath
+				if !strings.HasPrefix(entryPath, draftDir) {
+					if entry.IsDraft || !isLikelyGivenPath(entryPath) {
+						entry.CustomPath = entryPath
+					}
 				}
 			}
 			_, err = newBroker(bc, c.App.Writer).UploadFresh(entry)

--- a/main_test.go
+++ b/main_test.go
@@ -241,6 +241,43 @@ test`), 0644); err != nil {
 		}
 	})
 
+	t.Run("draft outside _draft with auto-assigned-like path", func(t *testing.T) {
+		t.Log("A draft file placed outside _draft/ with an auto-assigned-like path should keep its location")
+		now := time.Now()
+		autoDir := filepath.Join(dir, "entry", now.Format("2006"), now.Format("01"), now.Format("02"))
+		if err := os.MkdirAll(autoDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		autoPath := filepath.Join(autoDir, now.Format("150405")+".md")
+		if err := os.WriteFile(autoPath, []byte("---\nDraft: true\n---\ndraft outside _draft\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		entryFile, err := blogsync("push", autoPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			if _, err := blogsync("remove", entryFile); err != nil {
+				t.Fatal(err)
+			}
+		}()
+		if entryFile != autoPath {
+			t.Errorf("draft outside _draft/ should keep its path. got: %s, want: %s", entryFile, autoPath)
+		}
+
+		t.Log("Pushing the same draft again should still keep the file in place")
+		if err := appendFile(entryFile, "updated\n"); err != nil {
+			t.Fatal(err)
+		}
+		pushedFile, err := blogsync("push", entryFile)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if pushedFile != entryFile {
+			t.Errorf("second push should keep path. got: %s, want: %s", pushedFile, entryFile)
+		}
+	})
+
 	t.Run("post static pages", func(t *testing.T) {
 		t.Log("Posting a static page without a custom path results in an error")
 		app.Reader = strings.NewReader("static\n")


### PR DESCRIPTION
Closes #155

## Summary

`entry/_draft/` 外にある下書きエントリーは、カスタムURLが設定されていると見なし、push 時にファイル位置を保持するようにした。

## Changes

- `main.go`: push 時、下書きかつ `_draft/` 外なら `isLikelyGivenPath` でも CustomPath をセット
- `broker.go` `PutEntry`/`PostEntry`: `_draft/` 外の下書きは `localPath` を引き継いでファイル位置を保持
- `broker.go` `Store`: URL の nil 化は保存先が `_draft/` 内の場合のみに限定
- `main_test.go`: auto-assigned 風パスの下書きが `_draft/` 外でファイル位置を維持するテスト追加