### PR TITLE
Detect renamed files during pull and avoid duplicates

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"net/http"
@@ -34,6 +35,56 @@ func newBroker(bc *blogConfig, w io.Writer) *broker {
 		blogConfig: bc,
 		writer:     w,
 	}
+}
+
+// editURLFromFile extracts the EditURL from a file's frontmatter without
+// fully parsing the entry. Returns "" if not found.
+func editURLFromFile(fpath string) string {
+	f, err := os.Open(fpath)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	inFrontmatter := false
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "---" {
+			if inFrontmatter {
+				return ""
+			}
+			inFrontmatter = true
+			continue
+		}
+		if !inFrontmatter {
+			return ""
+		}
+		if strings.HasPrefix(line, "EditURL:") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "EditURL:"))
+		}
+	}
+	return ""
+}
+
+// buildLocalEntryMap walks the local root and builds a map of EditURL to file path
+// for all entry files.
+func (b *broker) buildLocalEntryMap() map[string]string {
+	m := map[string]string{}
+	root := b.localRoot()
+	filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(path, entryExt) {
+			return nil
+		}
+		if editURL := editURLFromFile(path); editURL != "" {
+			m[editURL] = path
+		}
+		return nil
+	})
+	return m
 }
 
 func (b *broker) FetchRemoteEntries(published, drafts bool) ([]*entry, error) {

--- a/main.go
+++ b/main.go
@@ -79,6 +79,7 @@ var commandPull = &cli.Command{
 			}
 
 			b := newBroker(blogConfig, c.App.Writer)
+			localEntryMap := b.buildLocalEntryMap()
 			remoteEntries, err := b.FetchRemoteEntries(
 				!c.Bool("only-drafts"), !c.Bool("no-drafts"))
 			if err != nil {
@@ -87,9 +88,24 @@ var commandPull = &cli.Command{
 
 			for _, re := range remoteEntries {
 				path := b.LocalPath(re)
-				_, err := b.StoreFresh(re, path)
-				if err != nil {
-					return err
+				if oldPath, ok := localEntryMap[re.EditURL]; ok && oldPath != path {
+					// Entry has been renamed locally
+					localMtime, _ := modTime(oldPath)
+					if localMtime.After(*re.LastModified) {
+						logf("warn", "local file is newer, skipping remote: %s", oldPath)
+						continue
+					}
+					logf("store", "renamed: %s -> %s", oldPath, path)
+					if _, err := b.StoreFresh(re, path); err != nil {
+						return err
+					}
+					if err := os.Remove(oldPath); err != nil && !os.IsNotExist(err) {
+						return err
+					}
+				} else {
+					if _, err := b.StoreFresh(re, path); err != nil {
+						return err
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

pull 時にローカルでリネームされたファイルを検知し、重複ファイルの発生を防止。

## Changes

- pull 開始時にローカルの全エントリーファイルを走査し EditURL → パス のマップを構築
- リモートエントリーの保存先が既存ファイルと異なる場合（リネーム検知）:
  - ローカル mtime がリモートより新しい → リモート保存をスキップ（ローカル優先）
  - リモートが新しい → URL ベースのパスに保存し、旧ファイルを削除
- EditURL 抽出はフロントマッターの軽量パースで行い、フルパースのオーバーヘッドを回避