### PR TITLE
Use ghr action for release uploads and add workflow_dispatch

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -16,10 +16,15 @@ runs:
       go-version-file: go.mod
   - name: release
     run: |
-      make crossbuild upload
+      make crossbuild
     shell: bash
     env:
       GITHUB_TOKEN: ${{ inputs.token }}
+  - uses: tcnksm/ghr@766f869eacbbb086e8860cf0f0192dda6e8e67e1 # v0.18.3
+    with:
+      tag: ${{ inputs.tag }}
+      token: ${{ inputs.token }}
+      path: "dist"
   - uses: haya14busa/action-update-semver@7d2c558640ea49e798d46539536190aff8c18715 # v1.5.1
     with:
       major_version_tag_only: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,11 @@ on:
   push:
     tags:
     - "v[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v0.20.0)"
+        required: true
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -13,7 +18,9 @@ jobs:
     - name: checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
+        ref: ${{ inputs.tag || github.ref_name }}
         persist-credentials: false
     - uses: ./.github/actions/release
       with:
+        tag: ${{ inputs.tag || github.ref_name }}
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ deps:
 
 .PHONY: devel-deps
 devel-deps:
-	go install github.com/tcnksm/ghr@latest
 	go install github.com/Songmu/godzil/cmd/godzil@latest
 
 .PHONY: test
@@ -37,7 +36,3 @@ crossbuild: go.sum devel-deps
 	godzil crossbuild -pv=v$(VERSION) -build-ldflags=$(BUILD_LDFLAGS) \
       -os=linux,darwin,windows -d=$(DIST_DIR) .
 	cd $(DIST_DIR) && shasum -a 256 $$(find * -type f -maxdepth 0) > SHA256SUMS
-
-.PHONY: upload
-upload:
-	ghr v$(VERSION) $(DIST_DIR)


### PR DESCRIPTION
## Changes

- `make crossbuild upload` → `make crossbuild` + `tcnksm/ghr` action でアップロード（gitrail と同じパターン）
- Makefile から `upload` ターゲットと `ghr` CLI インストールを削除
- `release.yaml` に `workflow_dispatch` を追加し、タグ指定での手動リリースに対応
- checkout 時に指定タグの ref をチェックアウト